### PR TITLE
Fix success log messages

### DIFF
--- a/lib/modules/build.js
+++ b/lib/modules/build.js
@@ -34,7 +34,7 @@ const build = (options = {}) => {
   // display build time
   const timeDiff = process.hrtime(startTime);
   const duration = timeDiff[0] * 1000 + timeDiff[1] / 1e6;
-  log.success(`Site built succesfully in ${duration}ms`);
+  log.success(`Site built successfully in ${duration}ms`);
 };
 
 /**

--- a/lib/modules/init.js
+++ b/lib/modules/init.js
@@ -26,7 +26,7 @@ const init = () => {
   cp.exec('npm i -D nanogen --loglevel error', () => {
     spinner.succeed();
 
-    log.success(`Site initialized succesfully!`);
+    log.success('Site initialized successfully');
     log.info(
       chalk`Now you can run:
   {cyan npm start}      to start your new site, or


### PR DESCRIPTION
## Summary
- correct spelling in success logs for build and init

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840635bb7408323823b7d9735203d9b