### PR TITLE
Use numeric port flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,8 +32,8 @@ const cli = meow(
         alias: 'c'
       },
       port: {
-        type: 'string',
-        default: '3000',
+        type: 'number',
+        default: 3000,
         alias: 'p'
       },
       help: {

--- a/test/modules/cli-process.test.js
+++ b/test/modules/cli-process.test.js
@@ -62,6 +62,7 @@ describe('cli', function() {
     // then
     expect(nanogen.serve.calledOnce).to.be.true;
     expect(nanogen.serve.args[0]).to.deep.equal([mockConfig, flags]);
+    expect(nanogen.serve.args[0][1].port).to.be.a('number');
   });
 
   it('should build site with default options', function() {


### PR DESCRIPTION
## Summary
- parse `--port` as a number in the CLI
- verify custom port is numeric in CLI process tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406383022c83238e3dd6cdff2f7779